### PR TITLE
Resolve unit test failures in 402

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This Moodle plugin displays a banner above course pages to users who have site r
 Branches
 -----------
 
-| Moodle version   | Branch                                                                                              | PHP  |
-|------------------|-----------------------------------------------------------------------------------------------------|------|
-| Moodle 3.9 +     | [MOODLE_39_STABLE](https://github.com/catalyst/moodle-local_switchrolebanner/tree/MOODLE_39_STABLE) | 7.4+ |
+| Moodle version          | Branch                                                                                                | PHP  |
+|-------------------------|-------------------------------------------------------------------------------------------------------|------|
+| Moodle 4.2 +            | [MOODLE_402_STABLE](https://github.com/catalyst/moodle-local_switchrolebanner/tree/MOODLE_402_STABLE) | 8.0+ |
+| Moodle 3.9 - Moodle 4.1 | [MOODLE_39_STABLE](https://github.com/catalyst/moodle-local_switchrolebanner/tree/MOODLE_39_STABLE)   | 7.4+ |

--- a/classes/external.php
+++ b/classes/external.php
@@ -27,13 +27,12 @@ namespace local_switchrolebanner;
 
 defined('MOODLE_INTERNAL') || die();
 
-require_once("$CFG->libdir/externallib.php");
-
-use external_api;
-use external_function_parameters;
-use external_value;
-use external_single_structure;
 use context_course;
+use core_external\external_api;
+use core_external\external_description;
+use core_external\external_function_parameters;
+use core_external\external_single_structure;
+use core_external\external_value;
 
 /**
  * External API class.

--- a/tests/helper_test.php
+++ b/tests/helper_test.php
@@ -28,11 +28,10 @@ namespace local_switchrolebanner;
 defined('MOODLE_INTERNAL') || die;
 
 global $CFG;
-require_once($CFG->libdir . '/externallib.php');
 
 use context_course;
 use context_system;
-use external_api;
+use core_external\external_api;
 
 /**
  * Class helper_test.

--- a/version.php
+++ b/version.php
@@ -26,5 +26,6 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->version   = 2023120801;              // Current version of the plugin (Date: YYYYMMDDXX).
-$plugin->requires  = 2020061524;              // Requires Moodle 3.9 and above.
+$plugin->requires  = 2023042400;              // Requires Moodle 4.2 and above.
 $plugin->component = 'local_switchrolebanner';
+$plugin->supported = [402, 403];


### PR DESCRIPTION
```
root@2305732fff4c:/var/www/site# vendor/bin/phpunit --stop-on-failure
Moodle 4.3.3+ (Build: 20240215), 7df2143073959fca876fec020aee95a53144c1ef
Php: 8.1.27, pgsql: 14.0 (Debian 14.0-1.pgdg110+1), OS: Linux 6.4.12-060412-generic x86_64

Fatal error: Uncaught coding_exception: Coding error detected, it must be fixed by a programmer: When including this file for a unit test, the test must be run in an isolated process. See the PHPUnit @runInSeparateProcess and @runTestsInSeparateProcesses annotations. in /var/www/site/lib/setuplib.php:2210
Stack trace:
#0 /var/www/site/lib/externallib.php(35): require_phpunit_isolation()
#1 /var/www/site/local/switchrolebanner/tests/helper_test.php(31): require_once('/var/www/cqu-mb...')
#2 /var/www/site/vendor/phpunit/phpunit/src/Util/FileLoader.php(66): include_once('/var/www/cqu-mb...')
#3 /var/www/site/vendor/phpunit/phpunit/src/Util/FileLoader.php(49): PHPUnit\Util\FileLoader::load('/var/www/cqu-mb...')
#4 /var/www/site/vendor/phpunit/phpunit/src/Framework/TestSuite.php(397): PHPUnit\Util\FileLoader::checkAndLoad('/var/www/cqu-mb...')
#5 /var/www/site/vendor/phpunit/phpunit/src/Framework/TestSuite.php(527): PHPUnit\Framework\TestSuite->addTestFile('/var/www/cqu-mb...')
#6 /var/www/site/vendor/phpunit/phpunit/src/TextUI/TestSuiteMapper.php(67): PHPUnit\Framework\TestSuite->addTestFiles(Array)
#7 /var/www/site/vendor/phpunit/phpunit/src/TextUI/Command.php(391): PHPUnit\TextUI\TestSuiteMapper->map(Object(PHPUnit\TextUI\XmlConfiguration\TestSuiteCollection), '')
#8 /var/www/site/vendor/phpunit/phpunit/src/TextUI/Command.php(112): PHPUnit\TextUI\Command->handleArguments(Array)
#9 /var/www/site/vendor/phpunit/phpunit/src/TextUI/Command.php(97): PHPUnit\TextUI\Command->run(Array, true)
#10 /var/www/site/vendor/phpunit/phpunit/phpunit(98): PHPUnit\TextUI\Command::main()
#11 /var/www/site/vendor/bin/phpunit(122): include('/var/www/cqu-mb...')
#12 {main}

Next PHPUnit\TextUI\RuntimeException: Coding error detected, it must be fixed by a programmer: When including this file for a unit test, the test must be run in an isolated process. See the PHPUnit @runInSeparateProcess and @runTestsInSeparateProcesses annotations. in /var/www/site/vendor/phpunit/phpunit/src/TextUI/Command.php:99
Stack trace:
#0 /var/www/site/vendor/phpunit/phpunit/phpunit(98): PHPUnit\TextUI\Command::main()
#1 /var/www/site/vendor/bin/phpunit(122): include('/var/www/cqu-mb...')
#2 {main}
  thrown in /var/www/site/vendor/phpunit/phpunit/src/TextUI/Command.php on line 99
```